### PR TITLE
feat: replace alpine with chainguard distroless images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,20 @@
-FROM golang:1.21.0-alpine as builder
+FROM cgr.dev/chainguard/go:latest as builder
 
-WORKDIR /usr/src
+WORKDIR /src
 
 COPY go.mod go.sum ./
-
 RUN go mod download && go mod verify
 
 ARG VERSION
 ARG COMMIT
 
 COPY . .
-RUN go build -ldflags="-s -w -X main.version=$VERSION -X main.commit=$COMMIT" -v -o /usr/local/bin/prog ./cmd/repeater/repeater.go
+RUN CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}" -o /bin/prog cmd/repeater/repeater.go
 
-FROM alpine:3.14
+FROM cgr.dev/chainguard/static:latest
 
-RUN apk add --no-cache ca-certificates
+USER nonroot
 
-COPY --from=builder /usr/local/bin/prog ./prog
+COPY --from=builder /bin/prog /prog
 
-ENTRYPOINT [ "sh", "-c", "update-ca-certificates && ./prog" ]
+ENTRYPOINT ["/prog"]


### PR DESCRIPTION
The aim of this pull request is to migrate the repeater's Docker image from an Alpine-based image to a distroless image. The main advantages are as follows:

- Reduced image size
- Reduced attack surface
- Makes a hacker's job more difficult by removing commonly used tools (e.g. shell / curl)
- Reduced scanner noise, so you know exactly which vulnerabilities are present in the image

The first distroless images were produced by [GoogleContainerTools](https://github.com/GoogleContainerTools/distroless), which has distroless images designed to run C, Go, Java, Node.js and Python images. Google's images are produced using a custom process orchestrated by their construction tool [Bazel](https://bazel.build/). Here are the benefits highlighted on their [GitHub](https://github.com/GoogleContainerTools/distroless#why-should-i-use-distroless-images):

> Restricting what's in your runtime container to precisely what's necessary for your app is a best practice employed by Google and other tech giants that have used containers in production for many years. It improves the signal to noise of scanners (e.g. CVE) and reduces the burden of establishing provenance to just what you need.

However, this pull request is based on [distroless images from Chainguard](https://www.chainguard.dev/chainguard-images). Chainguard distroless images are hardened and up-to-date distroless images. These images are easier to customize as there a build using [apko](https://github.com/chainguard-dev/apko) and [melange](https://github.com/chainguard-dev/melange) instead of [Bazel](https://bazel.build/). Here are the benefits highlighted on their [website](https://www.chainguard.dev/unchained/minimal-container-images-towards-a-more-secure-future):

> A key benefit of minimal images, which [we reported on previously](https://www.chainguard.dev/unchained/enforce-against-vulnerability-sprawl-with-up-to-date-images), is that the smaller surface can lead to a substantial reduction in the rate at which images accumulate CVEs [...]. We also see minimal images as a key mitigation for the growing evasion technique known as “living off the land,” which attackers are using to avoid intrusion detection software. Another benefit of minimal images is that they are small (comparing a crude sampling with official images, the average is 79% smaller).

In terms of hardening, they use a `nonroot` user [by default](https://www.chainguard.dev/unchained/into-the-deep-exploring-chainguard-container-images), which reduces the risk of container breakout. Chainguard images are built automatically every night to ensure that they are completely up to date and contain all available security patches. More details can be found on [their blog post](https://www.chainguard.dev/unchained/minimal-container-images-towards-a-more-secure-future).

While not a panacea, the use of distroless images is good practice for sensitive, long-term containers such as Escape's repeater agent.