### PR TITLE
feat: add ff for http redirects and upstream proxying

### DIFF
--- a/cmd/repeater/repeater.go
+++ b/cmd/repeater/repeater.go
@@ -78,6 +78,7 @@ func main() {
 				TLSClientConfig: &tls.Config{
 					InsecureSkipVerify: true,
 				},
+				Proxy: http.ProxyFromEnvironment,
 			},
 		}
 	}

--- a/cmd/repeater/repeater.go
+++ b/cmd/repeater/repeater.go
@@ -82,6 +82,12 @@ func main() {
 			},
 		}
 	}
+
+	disableRedirectsEnv := os.Getenv("ESCAPE_REPEATER_DISABLE_REDIRECTS")
+	if disableRedirectsEnv == "1" || disableRedirectsEnv == "true" {
+		roundtrip.DisableRedirects = true
+	}
+
 	logger.Info("Starting repeater client...")
 
 	go logger.AlwaysConnect(url, repeaterId)

--- a/pkg/roundtrip/roudtrip.go
+++ b/pkg/roundtrip/roudtrip.go
@@ -52,6 +52,8 @@ func HandleRequest(protoReq *proto.Request) *proto.Response {
 		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		}
+	} else {
+		client.CheckRedirect = nil
 	}
 
 	mTLS := false

--- a/pkg/roundtrip/roudtrip.go
+++ b/pkg/roundtrip/roudtrip.go
@@ -2,7 +2,6 @@ package roundtrip
 
 import (
 	"net/http"
-	"os"
 
 	"github.com/Escape-Technologies/repeater/pkg/logger"
 	proto "github.com/Escape-Technologies/repeater/proto/repeater/v1"
@@ -10,6 +9,7 @@ import (
 
 var DefaultClient = &http.Client{}
 var MTLSClient *http.Client = nil
+var DisableRedirects = false
 
 const mTLSHeader = "X-Escape-mTLS"
 
@@ -48,9 +48,7 @@ func HandleRequest(protoReq *proto.Request) *proto.Response {
 	}
 	client := DefaultClient
 
-	disableRedirects := os.Getenv("ESCAPE_REPEATER_DISABLE_REDIRECTS")
-
-	if httpReq.Header.Get("X-Disable-Redirects") == "true" || disableRedirects == "1" || disableRedirects == "true" {
+	if httpReq.Header.Get("X-Disable-Redirects") == "true" || DisableRedirects {
 		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		}

--- a/pkg/roundtrip/roudtrip.go
+++ b/pkg/roundtrip/roudtrip.go
@@ -2,6 +2,7 @@ package roundtrip
 
 import (
 	"net/http"
+	"os"
 
 	"github.com/Escape-Technologies/repeater/pkg/logger"
 	proto "github.com/Escape-Technologies/repeater/proto/repeater/v1"
@@ -46,6 +47,15 @@ func HandleRequest(protoReq *proto.Request) *proto.Response {
 		tls(protoReq.Url)
 	}
 	client := DefaultClient
+
+	disableRedirects := os.Getenv("ESCAPE_REPEATER_DISABLE_REDIRECTS")
+
+	if httpReq.Header.Get("X-Disable-Redirects") == "true" || disableRedirects == "1" || disableRedirects == "true" {
+		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+	}
+
 	mTLS := false
 	if httpReq.Header.Get(mTLSHeader) != "" {
 		if MTLSClient != nil {


### PR DESCRIPTION
```
ErrUseLastResponse can be returned by Client.CheckRedirect hooks to control how redirects are processed. If returned, the next request is not sent and the most recent response is returned with its body unclosed.
```